### PR TITLE
Stevens journal list (and nav and basePane)

### DIFF
--- a/Main.java
+++ b/Main.java
@@ -12,6 +12,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
+import view.JournalListPane;
 
 public class Main extends Application{
 
@@ -75,6 +76,13 @@ public class Main extends Application{
 
 
         primaryStage.setScene(login_scene);
+        primaryStage.show();
+        
+        
+        //TEMP
+        JournalListPane jlp = new JournalListPane(primaryStage);
+        Scene journalListScene = new Scene(jlp, 600, 600);
+        primaryStage.setScene(journalListScene);
         primaryStage.show();
     }
 

--- a/Main.java
+++ b/Main.java
@@ -11,8 +11,10 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.Pane;
 import javafx.stage.Stage;
 import view.JournalListPane;
+import view.ResearcherPane;
 
 public class Main extends Application{
 
@@ -29,39 +31,41 @@ public class Main extends Application{
         /*
         * Populate the login page
         */
-        BorderPane login_layout = new BorderPane();
-
-        TextField login_tf = new TextField();
-
-        Button login_b = new Button("Press Me");
-        // TODO: set this to have logic based on the account given as input
-        login_b.setOnAction(e -> {
-            primaryStage.setScene(researcher_scene);
-        });
-
-        login_layout.setTop(login_b);
-        login_layout.setCenter(login_tf);
-        login_scene = new Scene(login_layout, 800, 600);
+        //Pane loginPane = new view.LoginPane(primaryStage);
+        
+//        BorderPane login_layout = new BorderPane();
+//
+//        TextField login_tf = new TextField();
+//
+//        Button login_b = new Button("Press Me");
+//        // TODO: set this to have logic based on the account given as input
+//        login_b.setOnAction(e -> {
+//            primaryStage.setScene(researcher_scene);
+//        });
+//
+//        login_layout.setTop(login_b);
+//        login_layout.setCenter(login_tf);
+//        login_scene = new Scene(login_layout, 800, 600);
 
 
         /*
         * Populate the Researcher User page
         */
 
-        ResearcherPane researcher_layout = new ResearcherPane(primaryStage);
-        researcher_scene = new Scene(researcher_layout.getPane(), 600, 800);
+        //view.ResearcherPane researcher_layout = new view.ResearcherPane(primaryStage);
+        //researcher_scene = new Scene(researcher_layout.getPane(), 600, 800);
 
 
         /*
          * Populate the Reviewer User page
          */
 
-        ReviewerPane reviewer_layout = new ReviewerPane(primaryStage);
+        //view.ReviewerPane reviewer_layout = new view.ReviewerPane(primaryStage);
 
 
 
 
-        reviewer_scene = new Scene(reviewer_layout.getPane(), 600, 800);
+        //reviewer_scene = new Scene(reviewer_layout.getPane(), 600, 800);
 
 
 
@@ -69,9 +73,9 @@ public class Main extends Application{
          * Populate the Editor User page
          */
 
-        EditorPane editor_layout = new EditorPane(primaryStage);
+        //view.EditorPane editor_layout = new view.EditorPane(primaryStage);
 
-        editor_scene = new Scene(editor_layout.getPane(), 600, 800);
+        //editor_scene = new Scene(editor_layout.getPane(), 600, 800);
 
 
 

--- a/model/DataStore.java
+++ b/model/DataStore.java
@@ -40,12 +40,18 @@ public class DataStore implements Serializable {
 	 * serialization and deserialization code adapted from 
 	 * https://www.geeksforgeeks.org/object-graph-java-serialization/
 	 */	
-	public static DataStore load()  throws Exception {
-		FileInputStream fis = new FileInputStream("serialized.database"); 
-		ObjectInputStream ois = new ObjectInputStream(fis);
-		
-		DataStore db = (DataStore) ois.readObject();
-		
-		return db;
+	public static DataStore load() {
+		try {
+			FileInputStream fis = new FileInputStream("serialized.database"); 
+			ObjectInputStream ois = new ObjectInputStream(fis);
+			
+			DataStore db = (DataStore) ois.readObject();
+			
+			return db;
+		}
+		catch(Exception e) {
+			//TODO: This is terrible and should never have existed.
+			return new DataStore();
+		}
 	}
 }

--- a/model/University.java
+++ b/model/University.java
@@ -9,11 +9,11 @@ import java.util.List;
 public class University implements Serializable {
 
 	public String name;
-	public List<Journal> journals;
+	public ArrayList<Journal> journals;
 	
-	public List<Administrator> administrators;
+	public ArrayList<Administrator> administrators;
 	
-	public List<Reviewer> reviewers;
+	public ArrayList<Reviewer> reviewers;
 	
 	public University(String name) {
 		this.name = name;

--- a/view/BasePane.java
+++ b/view/BasePane.java
@@ -1,0 +1,22 @@
+package view;
+
+import javafx.scene.control.Label;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.Pane;
+import javafx.stage.Stage;
+
+public class BasePane extends BorderPane {
+
+	
+	public BasePane(Stage stage, String title) {
+		Label titleLabel = new Label(title);
+		Pane titlePane = new Pane();
+		titlePane.getChildren().addAll(titleLabel);
+		titlePane.setStyle("-fx-background-color: orange");
+		this.setTop(titlePane);
+		
+		
+		
+		this.setLeft(new NavigationPane(stage));
+	}
+}

--- a/view/EditorPane.java
+++ b/view/EditorPane.java
@@ -1,3 +1,4 @@
+package view;
 import javafx.application.Application;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -7,13 +8,20 @@ import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
-public class ReviewerPane extends StackPane{
+public class EditorPane extends BasePane {
+
     private StackPane pane;
-    public ReviewerPane(Stage ps){
+    public EditorPane(Stage ps){
+    	super(ps, "Editor Pane");
+    	
         pane = new StackPane();
-        Label reviewer_l = new Label("Reviewer");
-        pane.getChildren().addAll(reviewer_l);
+        Label editor_l = new Label("Editor");
+
+        pane.getChildren().addAll(editor_l);
+        
+        this.setCenter(pane);
     }
+
 
     public StackPane getPane(){
         return pane;

--- a/view/JournalListPane.java
+++ b/view/JournalListPane.java
@@ -1,0 +1,40 @@
+package view;
+
+import java.util.ArrayList;
+
+import javafx.scene.control.Label;
+import javafx.scene.layout.Background;
+import javafx.scene.layout.BackgroundFill;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.CornerRadii;
+
+import javafx.scene.paint.Color;
+import javafx.stage.Stage;
+import javafx.geometry.Insets;
+
+public class JournalListPane extends BorderPane {
+
+	private ArrayList<model.Journal> createFakeJournals() {
+		ArrayList<model.Journal> fake = new ArrayList<model.Journal>();
+		fake.add(new model.Journal("a fake journal"));
+		fake.add(new model.Journal("another fake journal"));
+		fake.add(new model.Journal("a third fake journal"));
+		fake.add(new model.Journal("a final fake journal"));
+		
+		return fake;
+	}
+	
+	public JournalListPane(Stage stage) {
+		
+		ArrayList<model.Journal> journals = createFakeJournals();
+		
+		Label titleLabel = new Label("Journal List Page");
+		
+		Pane topPane = new Pane();
+		topPane.getChildren().addAll(titleLabel);
+		
+		topPane.setBackground(new Background(Color.RED, CornerRadii.EMPTY, Insets.EMPTY));
+		
+		this.setTop(topPane);
+	}
+}

--- a/view/JournalListPane.java
+++ b/view/JournalListPane.java
@@ -17,7 +17,7 @@ import javafx.geometry.Insets;
 
 import model.Journal;
 
-public class JournalListPane extends BorderPane {
+public class JournalListPane extends BasePane {
 
 	private ArrayList<model.Journal> createFakeJournals() {
 		ArrayList<model.Journal> fake = new ArrayList<model.Journal>();
@@ -30,24 +30,11 @@ public class JournalListPane extends BorderPane {
 	}
 	
 	public JournalListPane(Stage stage) {
+		super(stage, "Journal List Page");
 		
 		ArrayList<model.Journal> journals = createFakeJournals();
 		
-		Label titleLabel = new Label("Journal List Page");
-		Pane titlePane = new Pane();
-		titlePane.getChildren().addAll(titleLabel);
-		titlePane.setStyle("-fx-background-color: orange");
-		this.setTop(titlePane);
-		
-		
-		Pane navPane = new Pane();
-		navPane.setStyle("-fx-background-color: cyan");
-		Label navLabel = new Label("Nav Label");
-		navPane.getChildren().addAll(navLabel);
-		this.setLeft(navPane);
-		
 		VBox contentPane = new VBox();
-		
 		
 		for (int i = 0; i < journals.size(); i++) { 
 			Pane journalBox = generateJournalListItem(journals.get(i));
@@ -55,7 +42,6 @@ public class JournalListPane extends BorderPane {
 			contentPane.getChildren().addAll(journalBox);
 		}
 		this.setCenter(contentPane);
-		
 	}
 	
 	public Pane generateJournalListItem(model.Journal journal) {

--- a/view/JournalListPane.java
+++ b/view/JournalListPane.java
@@ -2,15 +2,20 @@ package view;
 
 import java.util.ArrayList;
 
+import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Background;
 import javafx.scene.layout.BackgroundFill;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.CornerRadii;
-
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 import javafx.geometry.Insets;
+
+import model.Journal;
 
 public class JournalListPane extends BorderPane {
 
@@ -29,12 +34,38 @@ public class JournalListPane extends BorderPane {
 		ArrayList<model.Journal> journals = createFakeJournals();
 		
 		Label titleLabel = new Label("Journal List Page");
+		Pane titlePane = new Pane();
+		titlePane.getChildren().addAll(titleLabel);
+		titlePane.setStyle("-fx-background-color: orange");
+		this.setTop(titlePane);
 		
-		Pane topPane = new Pane();
-		topPane.getChildren().addAll(titleLabel);
 		
-		topPane.setBackground(new Background(Color.RED, CornerRadii.EMPTY, Insets.EMPTY));
+		Pane navPane = new Pane();
+		navPane.setStyle("-fx-background-color: cyan");
+		Label navLabel = new Label("Nav Label");
+		navPane.getChildren().addAll(navLabel);
+		this.setLeft(navPane);
 		
-		this.setTop(topPane);
+		VBox contentPane = new VBox();
+		
+		
+		for (int i = 0; i < journals.size(); i++) { 
+			Pane journalBox = generateJournalListItem(journals.get(i));
+			journalBox.setStyle("-fx-background-color: pink; -fx-padding: 10px;");
+			contentPane.getChildren().addAll(journalBox);
+		}
+		this.setCenter(contentPane);
+		
+	}
+	
+	public Pane generateJournalListItem(model.Journal journal) {
+		HBox container = new HBox();
+		
+		Label titleLabel = new Label(journal.name);
+		Button viewButton = new Button("View");
+		
+		container.getChildren().addAll(titleLabel, viewButton);
+		
+		return container;
 	}
 }

--- a/view/LoginPane.java
+++ b/view/LoginPane.java
@@ -1,0 +1,31 @@
+package view;
+
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.Pane;
+import javafx.stage.Stage;
+
+public class LoginPane extends BasePane {
+
+	public LoginPane(Stage primaryStage) {
+		super(primaryStage, "Login Page");
+		
+        TextField login_tf = new TextField();
+
+        BorderPane container = new BorderPane();
+        
+        Button login_b = new Button("Press Me");
+        // TODO: set this to have logic based on the account given as input
+        login_b.setOnAction(e -> {
+            //primaryStage.setScene(researcher_scene);
+        });
+
+        container.setTop(login_b);
+        container.setCenter(login_tf);
+        this.setCenter(container);
+        
+        //login_scene = new Scene(login_layout, 800, 600);
+	}
+}

--- a/view/NavigationPane.java
+++ b/view/NavigationPane.java
@@ -1,0 +1,57 @@
+package view;
+
+import java.lang.reflect.Constructor;
+import java.util.HashMap;
+
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.layout.HBox;
+//import javafx.stage.Stage;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+public class NavigationPane extends VBox {
+
+	private HashMap<String, Class<? extends Pane>> links = new HashMap<String, Class<? extends Pane>> ();
+	
+	
+	public NavigationPane(Stage primaryStage) {
+		links.put("Journal List", JournalListPane.class);
+		links.put("Login", LoginPane.class);
+		links.put("Researcher", ResearcherPane.class);
+		links.put("Reviewer", ReviewerPane.class);
+		links.put("Editor", EditorPane.class);
+		
+		links.forEach((name, pane) -> {
+			Button button = new Button(name);
+			
+			button.setOnAction(e -> {
+				try {
+					Constructor constructor = pane.getConstructor(Stage.class);
+					Pane newPane = (Pane) constructor.newInstance(primaryStage);
+					Scene newScene = generateSceneForPane(newPane);
+					primaryStage.setScene(newScene);
+			        //primaryStage.show();	
+				}
+				catch(Exception exception) {
+					// Swallowing exceptions is bad but I think it is impossible for a
+					// subclass of Pane not to have a constructor that takes a Stage object.
+					// Which would make this safe to do...
+				}
+				
+	        });
+			
+			getChildren().addAll(button);
+		});
+		
+		
+		setStyle("-fx-background-color: cyan");
+	}
+	
+	private Scene generateSceneForPane(Pane pane) {
+		Scene scene = new Scene(pane, 600, 600);
+        return scene;
+	}
+	
+}

--- a/view/ResearcherPane.java
+++ b/view/ResearcherPane.java
@@ -1,3 +1,4 @@
+package view;
 import javafx.application.Application;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -19,11 +20,14 @@ import java.io.OutputStream;
 import javafx.collections.FXCollections;
 import javafx.scene.control.ChoiceBox;
 
-class ResearcherPane extends StackPane{
+public class ResearcherPane extends BasePane {
     private StackPane pane;
     private File entry;
     private Label fileDir;
     public ResearcherPane(Stage ps){
+    	super(ps, "Researcher Pane");
+    	
+    	
         pane = new StackPane();
 
         Label researcher_l = new Label("Researcher");
@@ -38,6 +42,8 @@ class ResearcherPane extends StackPane{
         addChild(cb);
         
         addChild(researcher_l);
+        
+        this.setCenter(pane);
     }
 
     private void addChild(Node child){

--- a/view/ReviewerPane.java
+++ b/view/ReviewerPane.java
@@ -1,3 +1,4 @@
+package view;
 import javafx.application.Application;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -7,17 +8,17 @@ import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
-public class EditorPane extends StackPane{
-
+public class ReviewerPane extends BasePane {
     private StackPane pane;
-    public EditorPane(Stage ps){
+    public ReviewerPane(Stage ps){
+    	super(ps, "Reviewer Pane");
+    	
         pane = new StackPane();
-        Label editor_l = new Label("Editor");
-
-        pane.getChildren().addAll(editor_l);
-
+        Label reviewer_l = new Label("Reviewer");
+        pane.getChildren().addAll(reviewer_l);
+        
+        this.setCenter(pane);
     }
-
 
     public StackPane getPane(){
         return pane;


### PR DESCRIPTION
This pull request creates a few conventions for us to follow.

First, it creates a NagivationPane and a relatively easy way to add new "links" to the navigationPane.

Second, it creates a BasePane which all panes should extend. This BasePane takes a title as a constructor, which is in the "top" section of the underlying BorderPane. Then it creates a NavigationPane and sets that as the "left" section of the underlying BorderPane. This means all content for a page should go in the "center" section. 

This BasePane gives us a common pane for all our pages. Making is simple to give all pages a title and common navigation scheme as well as making it trivial to style all pages at the same time.

All existing pages have been converted into their own dedicated Pane classes which extend from BasePane and adapted to use the conventions set in BasePane. Note: All pane classes were moved into a "view" package.

The "Main" class was modified (mangled?) to work with this new setup, but it should be easy to test your own pages now as you can simply navigate to them.